### PR TITLE
Support serde for EVM Events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4179,7 +4179,7 @@ dependencies = [
 
 [[package]]
 name = "webb"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4189,6 +4189,7 @@ dependencies = [
  "openssl",
  "parity-scale-codec",
  "rand 0.8.5",
+ "serde",
  "serde_json",
  "sp-keyring",
  "subxt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,9 @@ members = [".", "proposals"]
 
 [package]
 name = "webb"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
-authors = [
-    "Webb Developers",
-]
+authors = ["Webb Developers"]
 license = "GPL-3.0"
 repository = "https://github.com/webb-tools/webb-rs"
 documentation = "https://docs.rs/webb"
@@ -41,6 +39,7 @@ ethers = { version = "0.6.0", default-features = false, optional = true, feature
 ] }
 # Used by ethers (but we need it to be vendored with the lib).
 openssl = { version = "0.10", features = ["vendored"], optional = true }
+serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -23,6 +23,8 @@ mod evm {
         let mut abi_file = NamedTempFile::new()?;
         abi_file.write_all(&abi)?;
         Abigen::new(contract_name, abi_file.path().to_string_lossy())?
+            .add_event_derive("serde::Serialize")
+            .add_event_derive("serde::Deserialize")
             .rustfmt(false) // don't use rustfmt for now.
             .generate()?
             .write_to_file(out)?;

--- a/src/evm/contract/protocol_solidity/anchor_handler.rs
+++ b/src/evm/contract/protocol_solidity/anchor_handler.rs
@@ -177,6 +177,8 @@ mod anchorhandlercontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "_bridgeAddress", abi = "_bridgeAddress()")]
     pub struct BridgeAddressCall;
@@ -189,6 +191,8 @@ mod anchorhandlercontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "_contractAddressToResourceID",
@@ -206,6 +210,8 @@ mod anchorhandlercontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "_contractWhitelist", abi = "_contractWhitelist(address)")]
     pub struct ContractWhitelistCall(pub ethers::core::types::Address);
@@ -218,6 +224,8 @@ mod anchorhandlercontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "_counts", abi = "_counts(uint256)")]
     pub struct CountsCall(pub ethers::core::types::U256);
@@ -230,6 +238,8 @@ mod anchorhandlercontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "_resourceIDToContractAddress",
@@ -245,6 +255,8 @@ mod anchorhandlercontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "_updateRecords", abi = "_updateRecords(uint256,uint256)")]
     pub struct UpdateRecordsCall(
@@ -260,6 +272,8 @@ mod anchorhandlercontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "executeProposal", abi = "executeProposal(bytes32,bytes)")]
     pub struct ExecuteProposalCall {
@@ -275,6 +289,8 @@ mod anchorhandlercontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "getUpdateRecord",
@@ -293,6 +309,8 @@ mod anchorhandlercontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "migrateBridge", abi = "migrateBridge(address)")]
     pub struct MigrateBridgeCall {
@@ -307,6 +325,8 @@ mod anchorhandlercontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "setResource", abi = "setResource(bytes32,address)")]
     pub struct SetResourceCall {
@@ -367,18 +387,14 @@ mod anchorhandlercontract_mod {
                     data.as_ref(),
                 )
             {
-                return Ok(AnchorHandlerContractCalls::ExecuteProposal(
-                    decoded,
-                ));
+                return Ok(AnchorHandlerContractCalls::ExecuteProposal(decoded));
             }
             if let Ok(decoded) =
                 <GetUpdateRecordCall as ethers::core::abi::AbiDecode>::decode(
                     data.as_ref(),
                 )
             {
-                return Ok(AnchorHandlerContractCalls::GetUpdateRecord(
-                    decoded,
-                ));
+                return Ok(AnchorHandlerContractCalls::GetUpdateRecord(decoded));
             }
             if let Ok(decoded) =
                 <MigrateBridgeCall as ethers::core::abi::AbiDecode>::decode(
@@ -523,7 +539,14 @@ mod anchorhandlercontract_mod {
     }
     #[doc = "`UpdateRecord(address,uint256,bytes32,bytes32,uint256)`"]
     #[derive(
-        Clone, Debug, Default, Eq, PartialEq, ethers :: contract :: EthAbiType,
+        Clone,
+        Debug,
+        Default,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     pub struct UpdateRecord {
         pub token_address: ethers::core::types::Address,

--- a/src/evm/contract/protocol_solidity/anchor_handler.rs
+++ b/src/evm/contract/protocol_solidity/anchor_handler.rs
@@ -387,14 +387,18 @@ mod anchorhandlercontract_mod {
                     data.as_ref(),
                 )
             {
-                return Ok(AnchorHandlerContractCalls::ExecuteProposal(decoded));
+                return Ok(AnchorHandlerContractCalls::ExecuteProposal(
+                    decoded,
+                ));
             }
             if let Ok(decoded) =
                 <GetUpdateRecordCall as ethers::core::abi::AbiDecode>::decode(
                     data.as_ref(),
                 )
             {
-                return Ok(AnchorHandlerContractCalls::GetUpdateRecord(decoded));
+                return Ok(AnchorHandlerContractCalls::GetUpdateRecord(
+                    decoded,
+                ));
             }
             if let Ok(decoded) =
                 <MigrateBridgeCall as ethers::core::abi::AbiDecode>::decode(

--- a/src/evm/contract/protocol_solidity/anchor_proxy.rs
+++ b/src/evm/contract/protocol_solidity/anchor_proxy.rs
@@ -222,9 +222,11 @@ mod anchorproxycontract_mod {
             Self: Sized,
         {
             if let Ok(decoded) = AnchorProxyDepositFilter::decode_log(log) {
-                return Ok(AnchorProxyContractEvents::AnchorProxyDepositFilter(
-                    decoded,
-                ));
+                return Ok(
+                    AnchorProxyContractEvents::AnchorProxyDepositFilter(
+                        decoded,
+                    ),
+                );
             }
             if let Ok(decoded) = EncryptedNoteFilter::decode_log(log) {
                 return Ok(AnchorProxyContractEvents::EncryptedNoteFilter(

--- a/src/evm/contract/protocol_solidity/anchor_proxy.rs
+++ b/src/evm/contract/protocol_solidity/anchor_proxy.rs
@@ -157,6 +157,8 @@ mod anchorproxycontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(
         name = "AnchorProxyDeposit",
@@ -177,6 +179,8 @@ mod anchorproxycontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(name = "EncryptedNote", abi = "EncryptedNote(address,bytes)")]
     pub struct EncryptedNoteFilter {
@@ -192,6 +196,8 @@ mod anchorproxycontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(
         name = "InstanceStateUpdated",
@@ -216,11 +222,9 @@ mod anchorproxycontract_mod {
             Self: Sized,
         {
             if let Ok(decoded) = AnchorProxyDepositFilter::decode_log(log) {
-                return Ok(
-                    AnchorProxyContractEvents::AnchorProxyDepositFilter(
-                        decoded,
-                    ),
-                );
+                return Ok(AnchorProxyContractEvents::AnchorProxyDepositFilter(
+                    decoded,
+                ));
             }
             if let Ok(decoded) = EncryptedNoteFilter::decode_log(log) {
                 return Ok(AnchorProxyContractEvents::EncryptedNoteFilter(
@@ -261,6 +265,8 @@ mod anchorproxycontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "anchorTrees", abi = "anchorTrees()")]
     pub struct AnchorTreesCall;
@@ -273,6 +279,8 @@ mod anchorproxycontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "backupNotes", abi = "backupNotes(bytes[])")]
     pub struct BackupNotesCall {
@@ -287,6 +295,8 @@ mod anchorproxycontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "deposit", abi = "deposit(address,bytes32,bytes)")]
     pub struct DepositCall {
@@ -303,6 +313,8 @@ mod anchorproxycontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "governance", abi = "governance()")]
     pub struct GovernanceCall;
@@ -315,6 +327,8 @@ mod anchorproxycontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "instances", abi = "instances(address)")]
     pub struct InstancesCall(pub ethers::core::types::Address);
@@ -327,6 +341,8 @@ mod anchorproxycontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "withdraw",
@@ -463,7 +479,14 @@ mod anchorproxycontract_mod {
     }
     #[doc = "`ExtData(bytes32,address,address,uint256,uint256)`"]
     #[derive(
-        Clone, Debug, Default, Eq, PartialEq, ethers :: contract :: EthAbiType,
+        Clone,
+        Debug,
+        Default,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     pub struct ExtData {
         pub refresh_commitment: [u8; 32],
@@ -474,7 +497,14 @@ mod anchorproxycontract_mod {
     }
     #[doc = "`Proof(bytes,bytes,bytes32,bytes32)`"]
     #[derive(
-        Clone, Debug, Default, Eq, PartialEq, ethers :: contract :: EthAbiType,
+        Clone,
+        Debug,
+        Default,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     pub struct Proof {
         pub proof: ethers::core::types::Bytes,

--- a/src/evm/contract/protocol_solidity/fixed_deposit_anchor.rs
+++ b/src/evm/contract/protocol_solidity/fixed_deposit_anchor.rs
@@ -607,6 +607,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(
         name = "Deposit",
@@ -628,6 +630,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(
         name = "EdgeAddition",
@@ -646,6 +650,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(
         name = "EdgeUpdate",
@@ -664,6 +670,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(name = "Insertion", abi = "Insertion(bytes32,uint32,uint256)")]
     pub struct InsertionFilter {
@@ -680,6 +688,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(name = "Refresh", abi = "Refresh(bytes32,bytes32,uint32)")]
     pub struct RefreshFilter {
@@ -696,6 +706,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(
         name = "Withdrawal",
@@ -791,6 +803,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "EVM_CHAIN_ID_TYPE", abi = "EVM_CHAIN_ID_TYPE()")]
     pub struct EvmChainIdTypeCall;
@@ -803,6 +817,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "FIELD_SIZE", abi = "FIELD_SIZE()")]
     pub struct FieldSizeCall;
@@ -815,6 +831,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "ROOT_HISTORY_SIZE", abi = "ROOT_HISTORY_SIZE()")]
     pub struct RootHistorySizeCall;
@@ -827,6 +845,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "ZERO_VALUE", abi = "ZERO_VALUE()")]
     pub struct ZeroValueCall;
@@ -839,6 +859,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "commitments", abi = "commitments(bytes32)")]
     pub struct CommitmentsCall(pub [u8; 32]);
@@ -851,6 +873,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "currentNeighborRootIndex",
@@ -866,6 +890,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "currentRootIndex", abi = "currentRootIndex()")]
     pub struct CurrentRootIndexCall;
@@ -878,6 +904,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "denomination", abi = "denomination()")]
     pub struct DenominationCall;
@@ -890,6 +918,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "deposit", abi = "deposit(bytes32)")]
     pub struct DepositCall {
@@ -904,6 +934,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "edgeExistsForChain", abi = "edgeExistsForChain(uint256)")]
     pub struct EdgeExistsForChainCall(pub ethers::core::types::U256);
@@ -916,6 +948,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "edgeIndex", abi = "edgeIndex(uint256)")]
     pub struct EdgeIndexCall(pub ethers::core::types::U256);
@@ -928,6 +962,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "edgeList", abi = "edgeList(uint256)")]
     pub struct EdgeListCall(pub ethers::core::types::U256);
@@ -940,6 +976,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "filledSubtrees", abi = "filledSubtrees(uint256)")]
     pub struct FilledSubtreesCall(pub ethers::core::types::U256);
@@ -952,6 +990,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "getChainId", abi = "getChainId()")]
     pub struct GetChainIdCall;
@@ -964,6 +1004,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "getChainIdType", abi = "getChainIdType()")]
     pub struct GetChainIdTypeCall;
@@ -976,6 +1018,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "getDenomination", abi = "getDenomination()")]
     pub struct GetDenominationCall;
@@ -988,6 +1032,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "getLastRoot", abi = "getLastRoot()")]
     pub struct GetLastRootCall;
@@ -1000,6 +1046,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "getLatestNeighborEdges",
@@ -1015,6 +1063,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "getLatestNeighborRoots",
@@ -1030,6 +1080,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "getProposalNonce", abi = "getProposalNonce()")]
     pub struct GetProposalNonceCall;
@@ -1042,6 +1094,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "getToken", abi = "getToken()")]
     pub struct GetTokenCall;
@@ -1054,6 +1108,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "handler", abi = "handler()")]
     pub struct HandlerCall;
@@ -1066,6 +1122,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "hasEdge", abi = "hasEdge(uint256)")]
     pub struct HasEdgeCall {
@@ -1080,6 +1138,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "hashLeftRight",
@@ -1099,6 +1159,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "hasher", abi = "hasher()")]
     pub struct HasherCall;
@@ -1111,6 +1173,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "isKnownNeighborRoot",
@@ -1129,6 +1193,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "isKnownRoot", abi = "isKnownRoot(bytes32)")]
     pub struct IsKnownRootCall {
@@ -1143,6 +1209,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "isSpent", abi = "isSpent(bytes32)")]
     pub struct IsSpentCall {
@@ -1157,6 +1225,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "isSpentArray", abi = "isSpentArray(bytes32[])")]
     pub struct IsSpentArrayCall {
@@ -1171,6 +1241,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "isValidRoots", abi = "isValidRoots(bytes32[])")]
     pub struct IsValidRootsCall {
@@ -1185,6 +1257,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "levels", abi = "levels()")]
     pub struct LevelsCall;
@@ -1197,6 +1271,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "maxEdges", abi = "maxEdges()")]
     pub struct MaxEdgesCall;
@@ -1209,6 +1285,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "neighborRoots", abi = "neighborRoots(uint256,uint32)")]
     pub struct NeighborRootsCall(pub ethers::core::types::U256, pub u32);
@@ -1221,6 +1299,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "nextIndex", abi = "nextIndex()")]
     pub struct NextIndexCall;
@@ -1233,6 +1313,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "nullifierHashes", abi = "nullifierHashes(bytes32)")]
     pub struct NullifierHashesCall(pub [u8; 32]);
@@ -1245,6 +1327,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "roots", abi = "roots(uint256)")]
     pub struct RootsCall(pub ethers::core::types::U256);
@@ -1257,6 +1341,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "setHandler", abi = "setHandler(address,uint32)")]
     pub struct SetHandlerCall {
@@ -1272,6 +1358,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "setVerifier", abi = "setVerifier(address,uint32)")]
     pub struct SetVerifierCall {
@@ -1287,6 +1375,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "token", abi = "token()")]
     pub struct TokenCall;
@@ -1299,6 +1389,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "unpackProof", abi = "unpackProof(uint256[8])")]
     pub struct UnpackProofCall {
@@ -1313,6 +1405,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "unwrapIntoNative", abi = "unwrapIntoNative(uint256)")]
     pub struct UnwrapIntoNativeCall {
@@ -1327,6 +1421,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "unwrapIntoToken",
@@ -1345,6 +1441,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "updateEdge", abi = "updateEdge(uint256,bytes32,uint256)")]
     pub struct UpdateEdgeCall {
@@ -1361,6 +1459,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "verifier", abi = "verifier()")]
     pub struct VerifierCall;
@@ -1373,6 +1473,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "withdraw",
@@ -1391,6 +1493,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "withdrawAndUnwrap",
@@ -1410,6 +1514,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "wrapAndDeposit", abi = "wrapAndDeposit(address,bytes32)")]
     pub struct WrapAndDepositCall {
@@ -1425,6 +1531,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "wrapNative", abi = "wrapNative()")]
     pub struct WrapNativeCall;
@@ -1437,6 +1545,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "wrapToken", abi = "wrapToken(address,uint256)")]
     pub struct WrapTokenCall {
@@ -1452,6 +1562,8 @@ mod fixeddepositanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "zeros", abi = "zeros(uint256)")]
     pub struct ZerosCall {
@@ -1586,11 +1698,9 @@ mod fixeddepositanchorcontract_mod {
                     data.as_ref(),
                 )
             {
-                return Ok(
-                    FixedDepositAnchorContractCalls::EdgeExistsForChain(
-                        decoded,
-                    ),
-                );
+                return Ok(FixedDepositAnchorContractCalls::EdgeExistsForChain(
+                    decoded,
+                ));
             }
             if let Ok(decoded) =
                 <EdgeIndexCall as ethers::core::abi::AbiDecode>::decode(
@@ -1620,9 +1730,7 @@ mod fixeddepositanchorcontract_mod {
                     data.as_ref(),
                 )
             {
-                return Ok(FixedDepositAnchorContractCalls::GetChainId(
-                    decoded,
-                ));
+                return Ok(FixedDepositAnchorContractCalls::GetChainId(decoded));
             }
             if let Ok(decoded) =
                 <GetChainIdTypeCall as ethers::core::abi::AbiDecode>::decode(
@@ -1785,9 +1893,7 @@ mod fixeddepositanchorcontract_mod {
                     data.as_ref(),
                 )
             {
-                return Ok(FixedDepositAnchorContractCalls::SetHandler(
-                    decoded,
-                ));
+                return Ok(FixedDepositAnchorContractCalls::SetHandler(decoded));
             }
             if let Ok(decoded) =
                 <SetVerifierCall as ethers::core::abi::AbiDecode>::decode(
@@ -1837,9 +1943,7 @@ mod fixeddepositanchorcontract_mod {
                     data.as_ref(),
                 )
             {
-                return Ok(FixedDepositAnchorContractCalls::UpdateEdge(
-                    decoded,
-                ));
+                return Ok(FixedDepositAnchorContractCalls::UpdateEdge(decoded));
             }
             if let Ok(decoded) =
                 <VerifierCall as ethers::core::abi::AbiDecode>::decode(
@@ -1878,9 +1982,7 @@ mod fixeddepositanchorcontract_mod {
                     data.as_ref(),
                 )
             {
-                return Ok(FixedDepositAnchorContractCalls::WrapNative(
-                    decoded,
-                ));
+                return Ok(FixedDepositAnchorContractCalls::WrapNative(decoded));
             }
             if let Ok(decoded) =
                 <WrapTokenCall as ethers::core::abi::AbiDecode>::decode(
@@ -2507,7 +2609,14 @@ mod fixeddepositanchorcontract_mod {
     }
     #[doc = "`ExtData(bytes32,address,address,uint256,uint256)`"]
     #[derive(
-        Clone, Debug, Default, Eq, PartialEq, ethers :: contract :: EthAbiType,
+        Clone,
+        Debug,
+        Default,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     pub struct ExtData {
         pub refresh_commitment: [u8; 32],
@@ -2518,7 +2627,14 @@ mod fixeddepositanchorcontract_mod {
     }
     #[doc = "`Proof(bytes,bytes,bytes32,bytes32)`"]
     #[derive(
-        Clone, Debug, Default, Eq, PartialEq, ethers :: contract :: EthAbiType,
+        Clone,
+        Debug,
+        Default,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     pub struct Proof {
         pub proof: ethers::core::types::Bytes,
@@ -2528,7 +2644,14 @@ mod fixeddepositanchorcontract_mod {
     }
     #[doc = "`Edge(uint256,bytes32,uint256)`"]
     #[derive(
-        Clone, Debug, Default, Eq, PartialEq, ethers :: contract :: EthAbiType,
+        Clone,
+        Debug,
+        Default,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     pub struct Edge {
         pub chain_id: ethers::core::types::U256,

--- a/src/evm/contract/protocol_solidity/fixed_deposit_anchor.rs
+++ b/src/evm/contract/protocol_solidity/fixed_deposit_anchor.rs
@@ -1698,9 +1698,11 @@ mod fixeddepositanchorcontract_mod {
                     data.as_ref(),
                 )
             {
-                return Ok(FixedDepositAnchorContractCalls::EdgeExistsForChain(
-                    decoded,
-                ));
+                return Ok(
+                    FixedDepositAnchorContractCalls::EdgeExistsForChain(
+                        decoded,
+                    ),
+                );
             }
             if let Ok(decoded) =
                 <EdgeIndexCall as ethers::core::abi::AbiDecode>::decode(
@@ -1730,7 +1732,9 @@ mod fixeddepositanchorcontract_mod {
                     data.as_ref(),
                 )
             {
-                return Ok(FixedDepositAnchorContractCalls::GetChainId(decoded));
+                return Ok(FixedDepositAnchorContractCalls::GetChainId(
+                    decoded,
+                ));
             }
             if let Ok(decoded) =
                 <GetChainIdTypeCall as ethers::core::abi::AbiDecode>::decode(
@@ -1893,7 +1897,9 @@ mod fixeddepositanchorcontract_mod {
                     data.as_ref(),
                 )
             {
-                return Ok(FixedDepositAnchorContractCalls::SetHandler(decoded));
+                return Ok(FixedDepositAnchorContractCalls::SetHandler(
+                    decoded,
+                ));
             }
             if let Ok(decoded) =
                 <SetVerifierCall as ethers::core::abi::AbiDecode>::decode(
@@ -1943,7 +1949,9 @@ mod fixeddepositanchorcontract_mod {
                     data.as_ref(),
                 )
             {
-                return Ok(FixedDepositAnchorContractCalls::UpdateEdge(decoded));
+                return Ok(FixedDepositAnchorContractCalls::UpdateEdge(
+                    decoded,
+                ));
             }
             if let Ok(decoded) =
                 <VerifierCall as ethers::core::abi::AbiDecode>::decode(
@@ -1982,7 +1990,9 @@ mod fixeddepositanchorcontract_mod {
                     data.as_ref(),
                 )
             {
-                return Ok(FixedDepositAnchorContractCalls::WrapNative(decoded));
+                return Ok(FixedDepositAnchorContractCalls::WrapNative(
+                    decoded,
+                ));
             }
             if let Ok(decoded) =
                 <WrapTokenCall as ethers::core::abi::AbiDecode>::decode(

--- a/src/evm/contract/protocol_solidity/signature_bridge.rs
+++ b/src/evm/contract/protocol_solidity/signature_bridge.rs
@@ -456,7 +456,9 @@ mod signaturebridgecontract_mod {
                 return Ok (SignatureBridgeContractEvents :: GovernanceOwnershipTransferredFilter (decoded));
             }
             if let Ok(decoded) = PausedFilter::decode_log(log) {
-                return Ok(SignatureBridgeContractEvents::PausedFilter(decoded));
+                return Ok(SignatureBridgeContractEvents::PausedFilter(
+                    decoded,
+                ));
             }
             if let Ok(decoded) = RecoveredAddressFilter::decode_log(log) {
                 return Ok(
@@ -1019,7 +1021,9 @@ mod signaturebridgecontract_mod {
                     data.as_ref(),
                 )
             {
-                return Ok(SignatureBridgeContractCalls::ProposalNonce(decoded));
+                return Ok(SignatureBridgeContractCalls::ProposalNonce(
+                    decoded,
+                ));
             }
             if let Ok(decoded) =
                 <ProposerSetRootCall as ethers::core::abi::AbiDecode>::decode(

--- a/src/evm/contract/protocol_solidity/signature_bridge.rs
+++ b/src/evm/contract/protocol_solidity/signature_bridge.rs
@@ -375,6 +375,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(
         name = "GovernanceOwnershipTransferred",
@@ -394,6 +396,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(name = "Paused", abi = "Paused(address)")]
     pub struct PausedFilter {
@@ -407,6 +411,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(name = "RecoveredAddress", abi = "RecoveredAddress(address)")]
     pub struct RecoveredAddressFilter {
@@ -421,6 +427,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(name = "Unpaused", abi = "Unpaused(address)")]
     pub struct UnpausedFilter {
@@ -448,9 +456,7 @@ mod signaturebridgecontract_mod {
                 return Ok (SignatureBridgeContractEvents :: GovernanceOwnershipTransferredFilter (decoded));
             }
             if let Ok(decoded) = PausedFilter::decode_log(log) {
-                return Ok(SignatureBridgeContractEvents::PausedFilter(
-                    decoded,
-                ));
+                return Ok(SignatureBridgeContractEvents::PausedFilter(decoded));
             }
             if let Ok(decoded) = RecoveredAddressFilter::decode_log(log) {
                 return Ok(
@@ -481,6 +487,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "EVM_CHAIN_ID_TYPE", abi = "EVM_CHAIN_ID_TYPE()")]
     pub struct EvmChainIdTypeCall;
@@ -493,6 +501,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "_counts", abi = "_counts(uint256)")]
     pub struct CountsCall(pub ethers::core::types::U256);
@@ -505,6 +515,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "_resourceIDToHandlerAddress",
@@ -520,6 +532,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "adminSetResourceWithSignature",
@@ -543,6 +557,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "averageSessionLengthInMillisecs",
@@ -558,6 +574,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "currentVotingPeriod", abi = "currentVotingPeriod()")]
     pub struct CurrentVotingPeriodCall;
@@ -570,6 +588,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "executeProposalWithSignature",
@@ -588,6 +608,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "getChainId", abi = "getChainId()")]
     pub struct GetChainIdCall;
@@ -600,6 +622,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "getChainIdType", abi = "getChainIdType()")]
     pub struct GetChainIdTypeCall;
@@ -612,6 +636,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "governor", abi = "governor()")]
     pub struct GovernorCall;
@@ -624,6 +650,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "isGovernor", abi = "isGovernor()")]
     pub struct IsGovernorCall;
@@ -636,6 +664,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "isSignatureFromGovernor",
@@ -654,6 +684,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "lastGovernorUpdateTime",
@@ -669,6 +701,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "numOfProposers", abi = "numOfProposers()")]
     pub struct NumOfProposersCall;
@@ -681,6 +715,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "paused", abi = "paused()")]
     pub struct PausedCall;
@@ -693,6 +729,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "proposalNonce", abi = "proposalNonce()")]
     pub struct ProposalNonceCall;
@@ -705,6 +743,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "proposerSetRoot", abi = "proposerSetRoot()")]
     pub struct ProposerSetRootCall;
@@ -717,6 +757,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "proposerSetUpdateNonce",
@@ -732,6 +774,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "recover", abi = "recover(bytes,bytes)")]
     pub struct RecoverCall {
@@ -747,6 +791,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "refreshNonce", abi = "refreshNonce()")]
     pub struct RefreshNonceCall;
@@ -759,6 +805,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "renounceOwnership", abi = "renounceOwnership()")]
     pub struct RenounceOwnershipCall;
@@ -771,6 +819,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "sessionLengthMultiplier",
@@ -786,6 +836,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "transferOwnership",
@@ -804,6 +856,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "transferOwnershipWithSignaturePubKey",
@@ -823,6 +877,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "updateProposerSetData",
@@ -844,6 +900,8 @@ mod signaturebridgecontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "voteInFavorForceSetGovernor",
@@ -961,9 +1019,7 @@ mod signaturebridgecontract_mod {
                     data.as_ref(),
                 )
             {
-                return Ok(SignatureBridgeContractCalls::ProposalNonce(
-                    decoded,
-                ));
+                return Ok(SignatureBridgeContractCalls::ProposalNonce(decoded));
             }
             if let Ok(decoded) =
                 <ProposerSetRootCall as ethers::core::abi::AbiDecode>::decode(
@@ -1188,7 +1244,14 @@ mod signaturebridgecontract_mod {
     }
     #[doc = "`Vote(uint32,bytes32[],address)`"]
     #[derive(
-        Clone, Debug, Default, Eq, PartialEq, ethers :: contract :: EthAbiType,
+        Clone,
+        Debug,
+        Default,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     pub struct Vote {
         pub leaf_index: u32,

--- a/src/evm/contract/protocol_solidity/variable_anchor.rs
+++ b/src/evm/contract/protocol_solidity/variable_anchor.rs
@@ -710,6 +710,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(
         name = "EdgeAddition",
@@ -728,6 +730,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(
         name = "EdgeUpdate",
@@ -746,6 +750,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(name = "Insertion", abi = "Insertion(bytes32,uint32,uint256)")]
     pub struct InsertionFilter {
@@ -762,6 +768,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(
         name = "NewCommitment",
@@ -780,6 +788,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(name = "NewNullifier", abi = "NewNullifier(bytes32)")]
     pub struct NewNullifierFilter {
@@ -793,6 +803,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthEvent,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethevent(name = "PublicKey", abi = "PublicKey(address,bytes)")]
     pub struct PublicKeyFilter {
@@ -870,6 +882,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "EVM_CHAIN_ID_TYPE", abi = "EVM_CHAIN_ID_TYPE()")]
     pub struct EvmChainIdTypeCall;
@@ -882,6 +896,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "FIELD_SIZE", abi = "FIELD_SIZE()")]
     pub struct FieldSizeCall;
@@ -894,6 +910,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "MAX_EXT_AMOUNT", abi = "MAX_EXT_AMOUNT()")]
     pub struct MaxExtAmountCall;
@@ -906,6 +924,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "MAX_FEE", abi = "MAX_FEE()")]
     pub struct MaxFeeCall;
@@ -918,6 +938,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "ROOT_HISTORY_SIZE", abi = "ROOT_HISTORY_SIZE()")]
     pub struct RootHistorySizeCall;
@@ -930,6 +952,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "ZERO_VALUE", abi = "ZERO_VALUE()")]
     pub struct ZeroValueCall;
@@ -942,6 +966,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "calculatePublicAmount",
@@ -960,6 +986,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "commitments", abi = "commitments(bytes32)")]
     pub struct CommitmentsCall(pub [u8; 32]);
@@ -972,6 +1000,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "configureMaximumDepositLimit",
@@ -989,6 +1019,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "configureMinimalWithdrawalLimit",
@@ -1006,6 +1038,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "currentNeighborRootIndex",
@@ -1021,6 +1055,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "currentRootIndex", abi = "currentRootIndex()")]
     pub struct CurrentRootIndexCall;
@@ -1033,6 +1069,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "edgeExistsForChain", abi = "edgeExistsForChain(uint256)")]
     pub struct EdgeExistsForChainCall(pub ethers::core::types::U256);
@@ -1045,6 +1083,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "edgeIndex", abi = "edgeIndex(uint256)")]
     pub struct EdgeIndexCall(pub ethers::core::types::U256);
@@ -1057,6 +1097,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "edgeList", abi = "edgeList(uint256)")]
     pub struct EdgeListCall(pub ethers::core::types::U256);
@@ -1069,6 +1111,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "filledSubtrees", abi = "filledSubtrees(uint256)")]
     pub struct FilledSubtreesCall(pub ethers::core::types::U256);
@@ -1081,6 +1125,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "getChainId", abi = "getChainId()")]
     pub struct GetChainIdCall;
@@ -1093,6 +1139,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "getChainIdType", abi = "getChainIdType()")]
     pub struct GetChainIdTypeCall;
@@ -1105,6 +1153,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "getLastRoot", abi = "getLastRoot()")]
     pub struct GetLastRootCall;
@@ -1117,6 +1167,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "getLatestNeighborEdges",
@@ -1132,6 +1184,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "getLatestNeighborRoots",
@@ -1147,6 +1201,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "getProposalNonce", abi = "getProposalNonce()")]
     pub struct GetProposalNonceCall;
@@ -1159,6 +1215,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "handler", abi = "handler()")]
     pub struct HandlerCall;
@@ -1171,6 +1229,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "hasEdge", abi = "hasEdge(uint256)")]
     pub struct HasEdgeCall {
@@ -1185,6 +1245,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "hashLeftRight",
@@ -1204,6 +1266,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "hasher", abi = "hasher()")]
     pub struct HasherCall;
@@ -1216,6 +1280,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "initialize", abi = "initialize(uint256,uint256)")]
     pub struct InitializeCall {
@@ -1231,6 +1297,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "isKnownNeighborRoot",
@@ -1249,6 +1317,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "isKnownRoot", abi = "isKnownRoot(bytes32)")]
     pub struct IsKnownRootCall {
@@ -1263,6 +1333,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "isSpent", abi = "isSpent(bytes32)")]
     pub struct IsSpentCall {
@@ -1277,6 +1349,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "isSpentArray", abi = "isSpentArray(bytes32[])")]
     pub struct IsSpentArrayCall {
@@ -1291,6 +1365,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "isValidRoots", abi = "isValidRoots(bytes32[])")]
     pub struct IsValidRootsCall {
@@ -1305,6 +1381,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "lastBalance", abi = "lastBalance()")]
     pub struct LastBalanceCall;
@@ -1317,6 +1395,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "levels", abi = "levels()")]
     pub struct LevelsCall;
@@ -1329,6 +1409,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "maxEdges", abi = "maxEdges()")]
     pub struct MaxEdgesCall;
@@ -1341,6 +1423,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "maximumDepositAmount", abi = "maximumDepositAmount()")]
     pub struct MaximumDepositAmountCall;
@@ -1353,6 +1437,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "minimalWithdrawalAmount",
@@ -1368,6 +1454,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "neighborRoots", abi = "neighborRoots(uint256,uint32)")]
     pub struct NeighborRootsCall(pub ethers::core::types::U256, pub u32);
@@ -1380,6 +1468,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "nextIndex", abi = "nextIndex()")]
     pub struct NextIndexCall;
@@ -1392,6 +1482,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "nullifierHashes", abi = "nullifierHashes(bytes32)")]
     pub struct NullifierHashesCall(pub [u8; 32]);
@@ -1404,6 +1496,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "register", abi = "register((address,bytes))")]
     pub struct RegisterCall {
@@ -1418,6 +1512,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "registerAndTransact",
@@ -1437,6 +1533,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "registerAndTransactWrap",
@@ -1457,6 +1555,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "roots", abi = "roots(uint256)")]
     pub struct RootsCall(pub ethers::core::types::U256);
@@ -1469,6 +1569,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "setHandler", abi = "setHandler(address,uint32)")]
     pub struct SetHandlerCall {
@@ -1484,6 +1586,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "setVerifier", abi = "setVerifier(address,uint32)")]
     pub struct SetVerifierCall {
@@ -1499,6 +1603,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "token", abi = "token()")]
     pub struct TokenCall;
@@ -1511,6 +1617,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "transact",
@@ -1529,6 +1637,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "transactWrap",
@@ -1548,6 +1658,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "unpackProof", abi = "unpackProof(uint256[8])")]
     pub struct UnpackProofCall {
@@ -1562,6 +1674,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "unwrapIntoNative",
@@ -1580,6 +1694,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "unwrapIntoToken",
@@ -1598,6 +1714,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "updateEdge", abi = "updateEdge(uint256,bytes32,uint256)")]
     pub struct UpdateEdgeCall {
@@ -1614,6 +1732,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "verifier", abi = "verifier()")]
     pub struct VerifierCall;
@@ -1626,6 +1746,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(
         name = "withdrawAndUnwrap",
@@ -1645,6 +1767,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "wrapAndDeposit", abi = "wrapAndDeposit(address,uint256)")]
     pub struct WrapAndDepositCall {
@@ -1660,6 +1784,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "wrapNative", abi = "wrapNative()")]
     pub struct WrapNativeCall;
@@ -1672,6 +1798,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "wrapToken", abi = "wrapToken(address,uint256)")]
     pub struct WrapTokenCall {
@@ -1687,6 +1815,8 @@ mod vanchorcontract_mod {
         PartialEq,
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     #[ethcall(name = "zeros", abi = "zeros(uint256)")]
     pub struct ZerosCall {
@@ -2633,7 +2763,14 @@ mod vanchorcontract_mod {
     }
     #[doc = "`Edge(uint256,bytes32,uint256)`"]
     #[derive(
-        Clone, Debug, Default, Eq, PartialEq, ethers :: contract :: EthAbiType,
+        Clone,
+        Debug,
+        Default,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     pub struct Edge {
         pub chain_id: ethers::core::types::U256,
@@ -2642,7 +2779,14 @@ mod vanchorcontract_mod {
     }
     #[doc = "`Account(address,bytes)`"]
     #[derive(
-        Clone, Debug, Default, Eq, PartialEq, ethers :: contract :: EthAbiType,
+        Clone,
+        Debug,
+        Default,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     pub struct Account {
         pub owner: ethers::core::types::Address,
@@ -2650,7 +2794,14 @@ mod vanchorcontract_mod {
     }
     #[doc = "`ExtData(address,int256,address,uint256,bytes,bytes)`"]
     #[derive(
-        Clone, Debug, Default, Eq, PartialEq, ethers :: contract :: EthAbiType,
+        Clone,
+        Debug,
+        Default,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     pub struct ExtData {
         pub recipient: ethers::core::types::Address,
@@ -2662,7 +2813,14 @@ mod vanchorcontract_mod {
     }
     #[doc = "`Proof(bytes,bytes,bytes32[],bytes32[2],uint256,bytes32)`"]
     #[derive(
-        Clone, Debug, Default, Eq, PartialEq, ethers :: contract :: EthAbiType,
+        Clone,
+        Debug,
+        Default,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        serde :: Serialize,
+        serde :: Deserialize,
     )]
     pub struct Proof {
         pub proof: ethers::core::types::Bytes,


### PR DESCRIPTION
This simply would allow us to use `serde` to any EVM Event in the generated code.