### PR TITLE
Update anchor update proposal with target system bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "webb-proposals"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "hex-literal",
  "num-traits",

--- a/proposals/Cargo.toml
+++ b/proposals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webb-proposals"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "Webb Protocol Proposals Specification & Implementation (part of webb-rs SDK)"
 categories = ["encoding", "no-std"]

--- a/proposals/src/header.rs
+++ b/proposals/src/header.rs
@@ -15,6 +15,22 @@ pub enum TargetSystem {
     TreeId(u32),
 }
 
+impl TargetSystem {
+    /// Turns `self` into a 32 byte array.
+    #[must_use]
+    pub fn into_fixed_bytes(self) -> [u8; 32] {
+        let encode = |elt: &[u8]| {
+            let mut bytes = [0u8; 32];
+            bytes[0..20].copy_from_slice(elt);
+            bytes
+        };
+        match self {
+            TargetSystem::ContractAddress(address) => encode(&address),
+            TargetSystem::TreeId(tree_id) => encode(&tree_id.to_le_bytes()),
+        }
+    }
+}
+
 /// Proposal Target Function Signature (4 bytes).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[cfg_attr(

--- a/proposals/src/proposal/anchor_update.rs
+++ b/proposals/src/proposal/anchor_update.rs
@@ -81,7 +81,6 @@ impl AnchorUpdateProposal {
         &self.target
     }
 
-
     /// Get the proposal as a bytes
     #[must_use]
     pub fn to_bytes(&self) -> [u8; Self::LENGTH] {

--- a/proposals/src/proposal/anchor_update.rs
+++ b/proposals/src/proposal/anchor_update.rs
@@ -9,11 +9,11 @@ use crate::{ProposalHeader, TypedChainId};
 ///
 /// The format of the proposal is:
 /// ```text
-/// ┌────────────────────┬─────────────────┬───────────────┬────────────────────┬────────────────┬────────────────┐
-/// │                    │                 │               │                    │                │                │
-/// │ ProposalHeader 40B │ SrcChainType 2B │ SrcChainId 4B │ LatestLeafIndex 4B │ MerkleRoot 32B │  Target ID 32B │
-/// │                    │                 │               │                    │                │                │
-/// └────────────────────┴─────────────────┴───────────────┴────────────────────┴────────────────┴────────────────┘
+/// ┌────────────────────┬─────────────────┬───────────────┬────────────────────┬────────────────┬───────────────┐
+/// │                    │                 │               │                    │                │               │
+/// │ ProposalHeader 40B │ SrcChainType 2B │ SrcChainId 4B │ LatestLeafIndex 4B │ MerkleRoot 32B │ Target ID 32B │
+/// │                    │                 │               │                    │                │               │
+/// └────────────────────┴─────────────────┴───────────────┴────────────────────┴────────────────┴───────────────┘
 /// ```
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
# Overview
This PR updates the anchor update metadata proposals with the target system as a 32-byte value. This change is primarily geared with saving even more information about edges so that end-user applications can rely on less external configuration. This is done by adding the contract addresses / tree ids we're bridging

## Related:
- [relayer](https://github.com/webb-tools/relayer/pull/165)
- [protocol-solidity](https://github.com/webb-tools/protocol-solidity/pull/142/)
- [protocol-substrate](https://github.com/webb-tools/protocol-substrate/pull/191)
