### PR TITLE
Rename a field in `evm/rescue_tokens` proposal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "webb-proposals"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "hex",
  "hex-literal",


### PR DESCRIPTION
Rename the `to_token_address` to `recipient`
Ref: https://github.com/webb-tools/webb-rs/pull/64#discussion_r920480438