### PR TITLE
Use workspace inheritance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,32 +1,45 @@
-[workspace]
-members = [".", "proposals"]
-
-[package]
-name = "webb"
-version = "0.5.14"
+[workspace.package]
 edition = "2021"
 authors = ["Webb Developers"]
 license = "GPL-3.0"
 repository = "https://github.com/webb-tools/webb-rs"
 documentation = "https://docs.rs/webb"
 homepage = "https://www.webb.tools"
+
+[workspace.dependencies]
+scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+serde = { version = "1.0.152", default-features = false, features = ["derive"] }
+hex = { version = "0.4", default-features = false }
+
+[package]
+name = "webb"
+version = "0.5.14"
 description = "Webb SDK"
 keywords = ["webb", "sdk", "blockchain", "webb-tools"]
 include = ["Cargo.toml", "contracts/", "metadata/", "src/**/*.rs", "build.rs", "README.md", "LICENSE"]
 build = "build.rs"
+edition = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+
+[workspace]
+members = [".", "proposals"]
 
 [dependencies]
 # Substrate crates.
 scale = { package = "parity-scale-codec", version = "3", default-features = false, optional = true }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"], optional = true }
+scale-info = { workspace = true, optional = true }
 subxt = { version = "0.25.0", optional = true }
 async-trait = "0.1"
 rand = { version = "0.8", default-features = false, features = ["getrandom"] }
 thiserror = "1.0.38"
-hex = { version = "0.4", default-features = false }
+hex = { workspace = true }
 # EVM crates.
 ethers = { version = "1.0.2", default-features = false, optional = true, features = ["legacy", "abigen"] }
-serde = { version = "1", default-features = false, features = ["derive"] }
+serde = { workspace = true }
 serde_json = { version = "1", optional = true }
 
 # Used by ethers (but we need it to be vendored with the lib).

--- a/proposals/Cargo.toml
+++ b/proposals/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
 name = "webb-proposals"
 version = "0.5.5"
-edition = "2021"
 description = "Webb Protocol Proposals Specification & Implementation (part of webb-rs SDK)"
 categories = ["encoding", "no-std"]
 keywords = ["webb", "proposals", "protocol", "blockchain"]
 readme = "../README.md"
-repository = "https://github.com/webb-tools/webb-rs"
-license = "Apache-2.0"
+edition = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
 
 [dependencies]
 scale-codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, optional = true, features = ["derive", "max-encoded-len"] }
@@ -17,11 +20,11 @@ num-traits = { version = "0.2.15", default-features = false }
 typed-builder = { version = "0.10.0", default-features = false, optional = true }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 schemars = "0.8.11"
-serde = { version = "1.0.152", default-features = false, features = ["derive"], optional = true}
+serde = { workspace = true, optional = true}
 
 [dev-dependencies]
 hex-literal = "0.3"
-hex = "0.4.3"
+hex = { workspace = true }
 
 [features]
 default = ["std", "evm", "substrate", "scale", "ink"]


### PR DESCRIPTION
Uses [workspace inheritance](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace) feature to avoid specifying metadata and dependencies more than once. I only did this for properties and deps which are identical in both crates. For `parity-scale-codec` it didnt work because there is some weird renaming.