### PR TITLE
Add debug impl with hex output for ResourceId and FunctionSignature

### DIFF
--- a/proposals/Cargo.toml
+++ b/proposals/Cargo.toml
@@ -20,7 +20,8 @@ num-traits = { version = "0.2.15", default-features = false }
 typed-builder = { version = "0.10.0", default-features = false, optional = true }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 schemars = "0.8.11"
-serde = { workspace = true, optional = true}
+serde = { workspace = true, optional = true }
+hex = { workspace = true }
 
 [dev-dependencies]
 hex-literal = "0.3"
@@ -28,7 +29,7 @@ hex = { workspace = true }
 
 [features]
 default = ["std", "evm", "substrate", "scale", "ink"]
-std = ["scale-codec/std", "scale-info/std", "num-traits/std", "serde"]
+std = ["scale-codec/std", "scale-info/std", "num-traits/std", "serde", "hex/std"]
 scale = ["scale-codec", "scale-info/derive"]
 evm = []
 substrate = ["scale-codec", "typed-builder"]

--- a/proposals/src/header.rs
+++ b/proposals/src/header.rs
@@ -2,12 +2,14 @@
 
 use crate::nonce::Nonce;
 use crate::target_system::TargetSystem;
+use core::fmt::Debug;
+use core::fmt::Formatter;
 
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 
 /// Proposal Target Function Signature (4 bytes).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[cfg_attr(
     feature = "scale",
     derive(
@@ -21,7 +23,7 @@ use serde::{Deserialize, Serialize};
 pub struct FunctionSignature(pub [u8; 4]);
 
 /// Proposal Target `ResourceId` (32 bytes).
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[cfg_attr(
     feature = "scale",
     derive(
@@ -493,6 +495,26 @@ impl scale_codec::Decode for ProposalHeader {
     fn encoded_fixed_size() -> Option<usize> {
         Some(Self::LENGTH)
     }
+}
+
+impl Debug for ResourceId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        format_bytes(&self.0, f)
+    }
+}
+
+impl Debug for FunctionSignature {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        format_bytes(&self.0, f)
+    }
+}
+
+fn format_bytes(bytes: &[u8], f: &mut Formatter<'_>) -> core::fmt::Result {
+    #[cfg(feature = "std")]
+    let res = f.write_str(&hex::encode(bytes));
+    #[cfg(not(feature = "std"))]
+    let res = bytes.fmt(f);
+    res
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I am debugging a problem in DKG (initial resource ids are not loaded correctly by chain spec). For this and other cases it would be very useful to see directly the hex representation of ResourceId, without having to convert manually.