### PR TITLE
[feat] Update `serde` support for `TypedChainId`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ hex = { version = "0.4", default-features = false }
 
 [package]
 name = "webb"
-version = "0.5.17"
+version = "0.5.18"
 description = "Webb SDK"
 keywords = ["webb", "sdk", "blockchain", "webb-tools"]
 include = ["Cargo.toml", "contracts/", "metadata/", "src/**/*.rs", "build.rs", "README.md", "LICENSE"]

--- a/proposals/Cargo.toml
+++ b/proposals/Cargo.toml
@@ -26,6 +26,7 @@ hex = { workspace = true }
 [dev-dependencies]
 hex-literal = "0.3"
 hex = { workspace = true }
+toml = { version = "0.7.2" }
 
 [features]
 default = ["std", "evm", "substrate", "scale", "ink"]

--- a/proposals/Cargo.toml
+++ b/proposals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webb-proposals"
-version = "0.5.16"
+version = "0.5.18"
 description = "Webb Protocol Proposals Specification & Implementation (part of webb-rs SDK)"
 categories = ["encoding", "no-std"]
 keywords = ["webb", "proposals", "protocol", "blockchain"]

--- a/proposals/src/proposal/evm/anchor_update.rs
+++ b/proposals/src/proposal/evm/anchor_update.rs
@@ -53,7 +53,7 @@ impl AnchorUpdateProposal {
         self.src_resource_id.typed_chain_id()
     }
 
-    /// Get the src_resource_id identifier.
+    /// Get the `src_resource_id` identifier.
     #[must_use]
     pub const fn src_resource_id(&self) -> ResourceId {
         self.src_resource_id

--- a/proposals/src/proposal/evm/wrapping_fee_update.rs
+++ b/proposals/src/proposal/evm/wrapping_fee_update.rs
@@ -26,7 +26,7 @@ impl WrappingFeeUpdateProposal {
 
     /// Creates a new wrapping fee update proposal.
     ///
-    /// Wrapping fee is in the range of 0 to 10_000.
+    /// Wrapping fee is in the range of 0 to `10_000`.
     ///
     /// **Note:** in debug mode, this may panic if the fee is out of range.
     #[must_use]
@@ -46,7 +46,7 @@ impl WrappingFeeUpdateProposal {
 
     /// Get the wrapping fee.
     ///
-    /// Wrapping fees are in the range [0, 10_000].
+    /// Wrapping fees are in the range [0, `10_000`].
     ///
     /// *Note*: In debug builds, this will panic if the wrapping fee is out of
     /// range.

--- a/proposals/src/proposal/ink/anchor_update.rs
+++ b/proposals/src/proposal/ink/anchor_update.rs
@@ -44,7 +44,7 @@ impl AnchorUpdateProposal {
         self.src_resource_id.typed_chain_id()
     }
 
-    /// Get the src_resource_id identifier.
+    /// Get the `src_resource_id` identifier.
     #[must_use]
     pub const fn src_resource_id(&self) -> ResourceId {
         self.src_resource_id

--- a/proposals/src/proposal/ink/fee_recipient_update.rs
+++ b/proposals/src/proposal/ink/fee_recipient_update.rs
@@ -33,7 +33,7 @@ impl FeeRecipientUpdateProposal {
     /// Get the fee recipient address.
     #[must_use]
     pub fn fee_recipient_address(&self) -> [u8; 32] {
-        self.fee_recipient_address.clone()
+        self.fee_recipient_address
     }
 
     /// Get the proposal as a bytes

--- a/proposals/src/proposal/ink/rescue_tokens.rs
+++ b/proposals/src/proposal/ink/rescue_tokens.rs
@@ -47,13 +47,13 @@ impl RescueTokensProposal {
     /// Get the token address.
     #[must_use]
     pub fn token_address(&self) -> [u8; 32] {
-        self.token_address.clone()
+        self.token_address
     }
 
     /// Get the to token address.
     #[must_use]
     pub fn recipient(&self) -> [u8; 32] {
-        self.recipient.clone()
+        self.recipient
     }
 
     /// Get the proposal as a bytes
@@ -65,8 +65,8 @@ impl RescueTokensProposal {
         let mut rescue_amt_bytes = [0u8; 16];
         rescue_amt_bytes.copy_from_slice(self.amount.split_at(16).1);
         let message = RescueTokens {
-            token_address: self.token_address.clone(),
-            to: self.recipient.clone(),
+            token_address: self.token_address,
+            to: self.recipient,
             amount_to_rescue: u128::from_be_bytes(rescue_amt_bytes),
             nonce: self.header.nonce().0,
         };

--- a/proposals/src/proposal/ink/resource_id_update.rs
+++ b/proposals/src/proposal/ink/resource_id_update.rs
@@ -48,13 +48,13 @@ impl ResourceIdUpdateProposal {
     /// Get the handler address.
     #[must_use]
     pub fn handler_address(&self) -> [u8; 32] {
-        self.handler_address.clone()
+        self.handler_address
     }
 
     /// Get the execution address.
     #[must_use]
     pub fn execution_address(&self) -> [u8; 32] {
-        self.execution_address.clone()
+        self.execution_address
     }
 
     /// Get the proposal as a bytes
@@ -68,8 +68,8 @@ impl ResourceIdUpdateProposal {
             function_sig: self.header.function_signature().to_bytes(),
             nonce: self.header.nonce().0,
             new_resource_id: self.new_resource_id.to_bytes(),
-            handler_addr: self.handler_address.clone(),
-            execution_context_addr: self.execution_address.clone(),
+            handler_addr: self.handler_address,
+            execution_context_addr: self.execution_address,
         };
         scale_codec::Encode::encode_to(&message, &mut bytes);
 

--- a/proposals/src/proposal/ink/set_treasury_handler.rs
+++ b/proposals/src/proposal/ink/set_treasury_handler.rs
@@ -33,7 +33,7 @@ impl SetTreasuryHandlerProposal {
     /// Get the handler address.
     #[must_use]
     pub fn handler_address(&self) -> [u8; 32] {
-        self.handler_address.clone()
+        self.handler_address
     }
 
     /// Get the proposal as a bytes
@@ -43,7 +43,7 @@ impl SetTreasuryHandlerProposal {
         bytes.extend_from_slice(&self.header.to_bytes());
 
         let message = SetHandler {
-            handler: self.handler_address.clone(),
+            handler: self.handler_address,
             nonce: self.header.nonce().0,
         };
         scale_codec::Encode::encode_to(&message, &mut bytes);

--- a/proposals/src/proposal/ink/token_add.rs
+++ b/proposals/src/proposal/ink/token_add.rs
@@ -33,7 +33,7 @@ impl TokenAddProposal {
     /// Get the token address.
     #[must_use]
     pub fn token_address(&self) -> [u8; 32] {
-        self.token_address.clone()
+        self.token_address
     }
 
     /// Get the proposal as a bytes
@@ -43,8 +43,8 @@ impl TokenAddProposal {
         bytes.extend_from_slice(&self.header.to_bytes());
 
         let message = AddPsp22TokenAddr {
-            token: self.token_address.clone(),
-            nonce: self.header.nonce().0 as u64,
+            token: self.token_address,
+            nonce: u64::from(self.header.nonce().0),
         };
         scale_codec::Encode::encode_to(&message, &mut bytes);
 

--- a/proposals/src/proposal/ink/token_remove.rs
+++ b/proposals/src/proposal/ink/token_remove.rs
@@ -33,7 +33,7 @@ impl TokenRemoveProposal {
     /// Get the token address.
     #[must_use]
     pub fn token_address(&self) -> [u8; 32] {
-        self.token_address.clone()
+        self.token_address
     }
 
     /// Get the proposal as a bytes
@@ -43,8 +43,8 @@ impl TokenRemoveProposal {
         bytes.extend_from_slice(&self.header.to_bytes());
 
         let message = RemovePsp22TokenAddr {
-            token: self.token_address.clone(),
-            nonce: self.header.nonce().0 as u64,
+            token: self.token_address,
+            nonce: u64::from(self.header.nonce().0),
         };
         scale_codec::Encode::encode_to(&message, &mut bytes);
 

--- a/proposals/src/proposal/ink/util.rs
+++ b/proposals/src/proposal/ink/util.rs
@@ -9,6 +9,7 @@ use tiny_keccak::{Hasher, Keccak};
 ///   Keccak256 hash:
 /// 7164f72199667ca6301626c67e4dba0a5a2e4cd1703af65d04e3e566845a4f7c
 ///   Target addr(hex):       7e4dba0a5a2e4cd1703af65d04e3e566845a4f7c
+#[must_use]
 pub fn ink_address_to_target_address(ink_address: [u8; 32]) -> [u8; 20] {
     let mut keccak = Keccak::v256();
     keccak.update(&ink_address);
@@ -24,7 +25,6 @@ pub fn ink_address_to_target_address(ink_address: [u8; 32]) -> [u8; 20] {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::proposal::ink::util::ink_address_to_target_address;
 
     #[test]
@@ -32,7 +32,7 @@ mod tests {
         let ink_addr = [0u8; 32];
         let expected = "88386fc84ba6bc95484008f6362f93160ef3e563".to_string();
 
-        let decoded = hex::decode(expected.clone()).unwrap();
+        let decoded = hex::decode(expected).unwrap();
 
         let target_addr = ink_address_to_target_address(ink_addr);
 

--- a/proposals/src/proposal/ink/wrapping_fee_update.rs
+++ b/proposals/src/proposal/ink/wrapping_fee_update.rs
@@ -16,7 +16,7 @@ pub struct WrappingFeeUpdateProposal {
 impl WrappingFeeUpdateProposal {
     /// Creates a new wrapping fee update proposal.
     ///
-    /// Wrapping fee is in the range of 0 to 10_000.
+    /// Wrapping fee is in the range of 0 to `10_000`.
     ///
     /// **Note:** in debug mode, this may panic if the fee is out of range.
     #[must_use]
@@ -36,7 +36,7 @@ impl WrappingFeeUpdateProposal {
 
     /// Get the wrapping fee.
     ///
-    /// Wrapping fees are in the range [0, 10_000].
+    /// Wrapping fees are in the range [0, `10_000`].
     ///
     /// *Note*: In debug builds, this will panic if the wrapping fee is out of
     /// range.

--- a/proposals/src/proposal/mod.rs
+++ b/proposals/src/proposal/mod.rs
@@ -114,6 +114,8 @@ pub enum Proposal<MaxLength: Get<u32>> {
     )
 )]
 /// Proposal kind enum
+#[allow(clippy::module_name_repetitions)]
+#[non_exhaustive]
 pub enum ProposalKind {
     /// Refresh proposal for DKG rotation
     Refresh,

--- a/proposals/src/proposal/mod.rs
+++ b/proposals/src/proposal/mod.rs
@@ -14,6 +14,7 @@ use frame_support::{pallet_prelude::Get, BoundedVec};
 
 /// The `Proposal` trait is used to abstract over the different proposals for
 /// all the different chains.
+#[allow(clippy::module_name_repetitions)]
 pub trait ProposalTrait {
     /// Get the proposal header.
     fn header(&self) -> crate::ProposalHeader;
@@ -154,6 +155,7 @@ pub enum ProposalKind {
 
 impl<MaxLength: Get<u32>> Proposal<MaxLength> {
     /// Returns the proposal data
+    #[must_use]
     pub fn data(&self) -> &Vec<u8> {
         match self {
             Proposal::Signed { data, .. } | Proposal::Unsigned { data, .. } => {
@@ -163,6 +165,7 @@ impl<MaxLength: Get<u32>> Proposal<MaxLength> {
     }
 
     /// Returns the proposal signature or None if it is unsigned
+    #[must_use]
     pub fn signature(&self) -> Option<Vec<u8>> {
         match self {
             Proposal::Signed { signature, .. } => {
@@ -173,20 +176,23 @@ impl<MaxLength: Get<u32>> Proposal<MaxLength> {
     }
 
     /// Returns the proposal kind
+    #[must_use]
     pub fn kind(&self) -> ProposalKind {
         match self {
             Proposal::Signed { kind, .. } | Proposal::Unsigned { kind, .. } => {
-                kind.clone()
+                *kind
             }
         }
     }
 
     /// Returns a boolean indicating if the proposal is signed
+    #[must_use]
     pub fn is_signed(&self) -> bool {
         matches!(self, Proposal::Signed { .. })
     }
 
     /// Returns a boolean indicating if the proposal is unsigned
+    #[must_use]
     pub fn is_unsigned(&self) -> bool {
         matches!(self, Proposal::Unsigned { .. })
     }

--- a/proposals/src/proposal/substrate/anchor_update.rs
+++ b/proposals/src/proposal/substrate/anchor_update.rs
@@ -8,7 +8,8 @@ use alloc::vec::Vec;
 ///
 /// The [`AnchorUpdateProposal`] updates a target Anchor's knowledge of the
 /// source Anchor's Merkle roots. This knowledge is necessary to prove
-/// membership in the source Anchor's Merkle tree on the src_resource_id chain.
+/// membership in the source Anchor's Merkle tree on the `src_resource_id`
+/// chain.
 #[allow(clippy::module_name_repetitions)]
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, Hash, typed_builder::TypedBuilder,
@@ -32,7 +33,7 @@ impl AnchorUpdateProposal {
         self.src_resource_id.typed_chain_id()
     }
 
-    /// Get the src_resource_id identifier.
+    /// Get the `src_resource_id` identifier.
     #[must_use]
     pub const fn src_resource_id(&self) -> ResourceId {
         self.src_resource_id
@@ -56,10 +57,7 @@ impl AnchorUpdateProposal {
         let mut out = Vec::with_capacity(120);
         let target_system = self.header().resource_id().target_system();
 
-        let target_details = match target_system {
-            TargetSystem::Substrate(target) => target,
-            _ => unreachable!("Unexpected target system for substrate"),
-        };
+        let TargetSystem::Substrate(target_details) = target_system else { unreachable!("Unexpected target system for substrate") };
 
         // add proposal header 40B
         out.extend_from_slice(&self.header.to_bytes());

--- a/proposals/src/proposal/substrate/fee_recipient_update.rs
+++ b/proposals/src/proposal/substrate/fee_recipient_update.rs
@@ -45,7 +45,7 @@ impl FeeRecipientUpdateProposal {
     /// Get the fee recipient.
     #[must_use]
     pub fn fee_recipient(&self) -> [u8; 32] {
-        self.fee_recipient.clone()
+        self.fee_recipient
     }
 
     /// Convert the proposal to a vector of bytes.
@@ -54,10 +54,7 @@ impl FeeRecipientUpdateProposal {
         let mut out = Vec::with_capacity(120);
         let target_system = self.header().resource_id().target_system();
 
-        let target_details = match target_system {
-            TargetSystem::Substrate(target) => target,
-            _ => unreachable!("Unexpected target system for substrate"),
-        };
+        let TargetSystem::Substrate(target_details) = target_system else { unreachable!("Unexpected target system for substrate") };
 
         // add proposal header 40B
         out.extend_from_slice(&self.header.to_bytes());

--- a/proposals/src/proposal/substrate/max_deposit_limit.rs
+++ b/proposals/src/proposal/substrate/max_deposit_limit.rs
@@ -47,10 +47,7 @@ impl MaxDepositLimitProposal {
         let mut out = Vec::new();
         let target_system = self.header().resource_id().target_system();
 
-        let target_details = match target_system {
-            TargetSystem::Substrate(target) => target,
-            _ => unreachable!("Unexpected target system for substrate"),
-        };
+        let TargetSystem::Substrate(target_details) = target_system else { unreachable!("Unexpected target system for substrate") };
         // add proposal header 40B
         out.extend_from_slice(&self.header.to_bytes());
 

--- a/proposals/src/proposal/substrate/min_withdrawal_limit.rs
+++ b/proposals/src/proposal/substrate/min_withdrawal_limit.rs
@@ -47,10 +47,7 @@ impl MinWithdrawalLimitProposal {
         let mut out = Vec::new();
         let target_system = self.header().resource_id().target_system();
 
-        let target_details = match target_system {
-            TargetSystem::Substrate(target) => target,
-            _ => unreachable!("Unexpected target system for substrate"),
-        };
+        let TargetSystem::Substrate(target_details) = target_system else { unreachable!("Unexpected target system for substrate") };
         // add proposal header 40B
         out.extend_from_slice(&self.header.to_bytes());
 

--- a/proposals/src/proposal/substrate/rescue_tokens.rs
+++ b/proposals/src/proposal/substrate/rescue_tokens.rs
@@ -48,19 +48,19 @@ impl RescueTokensProposal {
     /// Asset Id is the currency Id of token which will be rescued.
     #[must_use]
     pub fn asset_id(&self) -> u32 {
-        self.asset_id.clone()
+        self.asset_id
     }
 
     /// Get the recipient address where tokens will be transferred.
     #[must_use]
     pub fn recipient(&self) -> [u8; 32] {
-        self.recipient.clone()
+        self.recipient
     }
 
     /// Get the total amount to be rescued.
     #[must_use]
     pub fn rescue_amount(&self) -> u128 {
-        self.amount.clone()
+        self.amount
     }
 
     /// Convert the proposal to a vector of bytes.
@@ -69,10 +69,7 @@ impl RescueTokensProposal {
         let mut out = Vec::with_capacity(120);
         let target_system = self.header().resource_id().target_system();
 
-        let target_details = match target_system {
-            TargetSystem::Substrate(target) => target,
-            _ => unreachable!("Unexpected target system for substrate"),
-        };
+        let TargetSystem::Substrate(target_details) = target_system else { unreachable!("Unexpected target system for substrate") };
 
         // add proposal header 40B
         out.extend_from_slice(&self.header.to_bytes());

--- a/proposals/src/proposal/substrate/resource_id_update.rs
+++ b/proposals/src/proposal/substrate/resource_id_update.rs
@@ -41,10 +41,7 @@ impl ResourceIdUpdateProposal {
         let mut out = Vec::with_capacity(40 + 40 + 40 + 40);
         let target_system = self.header().resource_id().target_system();
 
-        let target_details = match target_system {
-            TargetSystem::Substrate(target) => target,
-            _ => unreachable!("Unexpected target system for substrate"),
-        };
+        let TargetSystem::Substrate(target_details) = target_system else { unreachable!("Unexpected target system for substrate") };
 
         out.extend_from_slice(&self.header.to_bytes());
         let call = ExecuteSetResourceProposal {
@@ -90,7 +87,7 @@ impl TryFrom<Vec<u8>> for ResourceIdUpdateProposal {
         // parse encoded proposal call
         let call: ExecuteSetResourceProposal =
             scale_codec::Decode::decode(&mut &value[42..])?;
-        let new_resource_id = ResourceId::from(call.r_id);
+        let new_resource_id = call.r_id;
         let proposal = ResourceIdUpdateProposal {
             header,
             new_resource_id,

--- a/proposals/src/proposal/substrate/token_add.rs
+++ b/proposals/src/proposal/substrate/token_add.rs
@@ -41,10 +41,7 @@ impl TokenAddProposal {
         let mut out = Vec::with_capacity(40 + 40 + self.name.len());
         let target_system = self.header().resource_id().target_system();
 
-        let target_details = match target_system {
-            TargetSystem::Substrate(target) => target,
-            _ => unreachable!("Unexpected target system for substrate"),
-        };
+        let TargetSystem::Substrate(target_details) = target_system else { unreachable!("Unexpected target system for substrate") };
 
         // add proposal header 40B
         out.extend_from_slice(&self.header.to_bytes());

--- a/proposals/src/proposal/substrate/token_remove.rs
+++ b/proposals/src/proposal/substrate/token_remove.rs
@@ -43,10 +43,7 @@ impl TokenRemoveProposal {
         let mut out = Vec::with_capacity(40 + 40 + self.name.len());
         let target_system = self.header().resource_id().target_system();
 
-        let target_details = match target_system {
-            TargetSystem::Substrate(target) => target,
-            _ => unreachable!("Unexpected target system for substrate"),
-        };
+        let TargetSystem::Substrate(target_details) = target_system else { unreachable!("Unexpected target system for substrate") };
 
         // add proposal header 40B
         out.extend_from_slice(&self.header.to_bytes());

--- a/proposals/src/proposal/substrate/wrapping_fee_update.rs
+++ b/proposals/src/proposal/substrate/wrapping_fee_update.rs
@@ -52,10 +52,7 @@ impl WrappingFeeUpdateProposal {
         let mut out = Vec::new();
         let target_system = self.header().resource_id().target_system();
 
-        let target_details = match target_system {
-            TargetSystem::Substrate(target) => target,
-            _ => unreachable!("Unexpected target system for substrate"),
-        };
+        let TargetSystem::Substrate(target_details) = target_system else { unreachable!("Unexpected target system for substrate") };
         // add proposal header 40B
         out.extend_from_slice(&self.header.to_bytes());
 

--- a/proposals/src/target_system.rs
+++ b/proposals/src/target_system.rs
@@ -1,29 +1,30 @@
-/// The Proposal Target System.
+//! The Proposal Target System.
 
-/// Target system format for Substrate
-/// ┌─────────────────────┬───────┬───────┬─────────────┐
-/// │                     │       │       │             │
-/// │           Zeros     │ Pallet│ Call  │   Tree ID   │
-/// │           (20B)     │  Idx  │  Idx  │    (4B)     │
-/// │                     │       │       │             │
-/// └─────────────────────┴───────┴───────┴─────────────┘
-///                       ▲       ▲       ▲             ▲
-///                       │   20  │   21  │ 22 23 24 25 │
-///                       │       │       │             │
-///
-/// Target system format for Evm
-/// ┌────────────────┬──────────────────────────────────┐
-/// │                │                                  │
-/// │      Zeros     │     Contract Address             │
-/// │      (6B)      │           (20B)                  │
-/// │                │                                  │
-/// └────────────────┘──────────────────────────────────┘
-///                  ▲                                  ▲
-///                  │ 6                             25 │
-///                  │                                  │
+//! Target system format for Substrate
+//! ┌─────────────────────┬───────┬───────┬─────────────┐
+//! │                     │       │       │             │
+//! │           Zeros     │ Pallet│ Call  │   Tree ID   │
+//! │           (20B)     │  Idx  │  Idx  │    (4B)     │
+//! │                     │       │       │             │
+//! └─────────────────────┴───────┴───────┴─────────────┘
+//!                       ▲       ▲       ▲             ▲
+//!                       │   20  │   21  │ 22 23 24 25 │
+//!                       │       │       │             │
+//!
+//! Target system format for Evm
+//! ┌────────────────┬──────────────────────────────────┐
+//! │                │                                  │
+//! │      Zeros     │     Contract Address             │
+//! │      (6B)      │           (20B)                  │
+//! │                │                                  │
+//! └────────────────┘──────────────────────────────────┘
+//!                  ▲                                  ▲
+//!                  │ 6                             25 │
+//!                  │                                  │
+
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-/// TargetSystem (26 Bytes)
+/// `TargetSystem` (26 Bytes)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(
     feature = "scale",
@@ -55,6 +56,7 @@ pub enum TargetSystem {
     )
 )]
 #[cfg(feature = "substrate")]
+#[allow(clippy::module_name_repetitions)]
 pub struct SubstrateTargetSystem {
     /// Pallet index of proposal handler pallet
     pub pallet_index: u8,
@@ -101,7 +103,7 @@ impl TargetSystem {
         self.to_bytes()
     }
 
-    /// Get substrate TargetSystem details
+    /// Get substrate `TargetSystem` details
     #[cfg(feature = "substrate")]
     #[must_use]
     pub fn get_substrate_target_system(self) -> Option<SubstrateTargetSystem> {

--- a/proposals/src/target_system.rs
+++ b/proposals/src/target_system.rs
@@ -35,6 +35,7 @@ use alloc::vec::Vec;
         scale_codec::MaxEncodedLen
     )
 )]
+#[non_exhaustive]
 pub enum TargetSystem {
     /// Ethereum Contract address (20 bytes).
     ContractAddress([u8; 20]),
@@ -42,6 +43,7 @@ pub enum TargetSystem {
     #[cfg(feature = "substrate")]
     Substrate(SubstrateTargetSystem),
 }
+
 /// Substrate Target System
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Hash, typed_builder::TypedBuilder,

--- a/proposals/src/traits.rs
+++ b/proposals/src/traits.rs
@@ -6,6 +6,11 @@ use frame_support::pallet_prelude::Get;
 pub trait OnSignedProposal<E, MaxLength: Get<u32>> {
     /// On a signed proposal, this method is called.
     /// It returns a result `()` and otherwise an error of type `E`.
+    ///
+    /// ## Errors
+    ///
+    /// 1. If the proposal is not signed.
+    /// 2. If the proposal is not valid.
     fn on_signed_proposal(proposal: Proposal<MaxLength>) -> Result<(), E>;
 }
 

--- a/src/substrate/mod.rs
+++ b/src/substrate/mod.rs
@@ -5,6 +5,7 @@
     clippy::module_inception,
     clippy::large_enum_variant
 )]
+#![warn(clippy::manual_non_exhaustive)]
 
 pub mod dkg_runtime;
 pub mod protocol_substrate_runtime;


### PR DESCRIPTION
### Changes
1. Update serde support for the TypedChainId ([_Rust Playground Example_](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=0711fed44431b4ed0e4c3b0ea52f7e07))
2. Clippy fixes and lints
3. mark our enums as `non_exhaustive` when possible; to force users to handle every single possible case instead of using the `_` wildcard for matching other cases.
4. pumped the webb-proposals & webb-rs version

### TypedChainId representation in files

*  In `toml` files like the following:
```toml
typed-chain-id = { type = "Evm", id = 42 }
```
*  In `json` files it will look like the following:
```json
{ "typedChainId": { "type": "Evm", "id": 42 } }
```