### PR TITLE
deps: Update ethers to the latest commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ keywords = ["webb", "sdk", "blockchain", "webb-tools"]
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.152", default-features = false, features = ["derive"] }
 hex = { version = "0.4", default-features = false }
-# ethers = { version = "2.0.2", git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["legacy", "abigen"] }
-ethers = { git = "https://github.com/shekohex/ethers-rs", branch = "shekohex/etherscan-gasoracle-response", default-features = false, features = ["legacy", "abigen"] }
+ethers = { version = "2.0.2", git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["legacy", "abigen"] }
 thiserror = "1"
 
 [package]


### PR DESCRIPTION
https://github.com/gakonst/ethers-rs/pull/2325 just got merged, we can now use the ethers-rs master branch instead of my fork.