### PR TITLE
Add deploy Poseidon Hasher method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["webb", "sdk", "blockchain", "webb-tools"]
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.152", default-features = false, features = ["derive"] }
 hex = { version = "0.4", default-features = false }
-ethers = { version = "2.0.2", git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["legacy", "abigen"] }
+ethers = { version = "2.0.4", default-features = false, features = ["legacy", "abigen"] }
 thiserror = "1"
 
 [package]
@@ -31,7 +31,7 @@ documentation = { workspace = true }
 homepage = { workspace = true }
 
 [workspace]
-members = [".", "proposals", "bridge-proofs"]
+members = [".", "proposals", "bridge-proofs", "evm-test-utils"]
 
 [dependencies]
 # Substrate crates.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rand = { version = "0.8", default-features = false, features = ["getrandom"] }
 thiserror = "1.0.38"
 hex = { workspace = true }
 # EVM crates.
-ethers = { workspace = true, optional = true, features = ["legacy", "abigen"] }
+ethers = { workspace = true, optional = true, features = ["legacy", "abigen", "ethers-solc"] }
 serde = { workspace = true }
 serde_json = { version = "1", optional = true }
 

--- a/evm-test-utils/Cargo.toml
+++ b/evm-test-utils/Cargo.toml
@@ -13,7 +13,7 @@ documentation = { workspace = true }
 homepage = { workspace = true }
 
 [dependencies]
-anvil = { git = "https://github.com/foundry-rs/foundry.git", rev = "6570a4c" }
+anvil = { git = "https://github.com/foundry-rs/foundry.git", rev = "9751242" }
 futures = "0.3"
 hex = { workspace = true }
 webb-proposals = { path = "../proposals", default-features = false }

--- a/evm-test-utils/src/errors.rs
+++ b/evm-test-utils/src/errors.rs
@@ -2,6 +2,9 @@ use webb::evm::ethers;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// IO error.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
     /// Smart contract error.
     #[error(transparent)]
     EthersContract(

--- a/evm-test-utils/src/local_evm_chain.rs
+++ b/evm-test-utils/src/local_evm_chain.rs
@@ -104,7 +104,8 @@ impl LocalEvmChain {
     }
 
     pub fn shutdown(mut self) {
-        let maybe_signal = self.anvil_node_handle.shutdown_signal_mut().take();
+        let maybe_signal =
+            Option::take(self.anvil_node_handle.shutdown_signal_mut());
         if let Some(signal) = maybe_signal {
             signal.fire().expect("signal fired");
         }

--- a/src/evm/contract/protocol_solidity/mod.rs
+++ b/src/evm/contract/protocol_solidity/mod.rs
@@ -36,16 +36,14 @@ pub mod poseidon_hasher_factory {
     use std::sync::Arc;
 
     use ethers::prelude::*;
-    use ethers::solc::{
-        artifacts::ContractBytecode, ConfigurableContractArtifact,
-    };
+    use ethers::solc::artifacts::ContractBytecode;
 
-    pub const ARTIFACT_PATH: &str =
-        "../../../../contracts/protocol-solidity/PoseidonHasher.json";
+    pub const ARTIFACT: &str = include_str!(
+        "../../../../contracts/protocol-solidity/PoseidonHasher.json"
+    );
 
     fn contract_bytecode() -> std::io::Result<ContractBytecode> {
-        let s = std::fs::read_to_string(ARTIFACT_PATH)?;
-        let artifact = serde_json::from_str::<ConfigurableContractArtifact>(&s)
+        let artifact = serde_json::from_str::<HardhatArtifact>(&ARTIFACT)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
         let contract = artifact.into_contract_bytecode();
         let bytecode: ContractBytecode = contract.into();

--- a/src/evm/contract/protocol_solidity/mod.rs
+++ b/src/evm/contract/protocol_solidity/mod.rs
@@ -31,3 +31,59 @@ pub use treasury::*;
 pub use treasury_handler::*;
 pub use vanchor_base::*;
 pub use variable_anchor::*;
+
+pub mod poseidon_hasher_factory {
+    use std::sync::Arc;
+
+    use ethers::prelude::*;
+    use ethers::solc::{
+        artifacts::ContractBytecode, ConfigurableContractArtifact,
+    };
+
+    pub const ARTIFACT_PATH: &str =
+        "../../../../contracts/protocol-solidity/PoseidonHasher.json";
+
+    fn contract_bytecode() -> std::io::Result<ContractBytecode> {
+        let s = std::fs::read_to_string(ARTIFACT_PATH)?;
+        let artifact = serde_json::from_str::<ConfigurableContractArtifact>(&s)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        let contract = artifact.into_contract_bytecode();
+        let bytecode: ContractBytecode = contract.into();
+        Ok(bytecode)
+    }
+
+    pub fn create<M>(
+        t3: Address,
+        t4: Address,
+        t6: Address,
+        client: Arc<M>,
+    ) -> std::io::Result<ContractFactory<M>>
+    where
+        M: Middleware,
+    {
+        let abi = super::POSEIDONHASHERCONTRACT_ABI.clone();
+        let mut bytecode_unlinked = contract_bytecode()?;
+        if let Some(ref mut bytecode) = bytecode_unlinked.bytecode {
+            bytecode.link_all_fully_qualified([
+                ("contracts/hashers/Poseidon.sol:PoseidonT3", t3),
+                ("contracts/hashers/Poseidon.sol:PoseidonT4", t4),
+                ("contracts/hashers/Poseidon.sol:PoseidonT6", t6),
+            ]);
+        }
+        let bytecode = bytecode_unlinked.bytecode.ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::Other, "missing bytecode")
+        })?;
+        debug_assert!(
+            bytecode.object.is_bytecode(),
+            "bytecode is not fully linked"
+        );
+        let raw_bytecode = bytecode.object.into_bytes().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "bytecode is not fully linked",
+            )
+        })?;
+        let factory = ContractFactory::new(abi, raw_bytecode, client);
+        Ok(factory)
+    }
+}


### PR DESCRIPTION
## Changes
1. Updated ethers to v2.0.4
2. Added `deploy_poseidon_hasher()` method to the `LocalEvmChain`
3. Added a test case to make sure the deployment works.
```js
const { poseidon } = require('circomlib');
console.log(poseidon([1, 2]).toString(16)); // 115cc0f5e7d690413df64c6b9662e9cf2a3617f2743245519e19607a4417189a
```

Closes https://github.com/webb-tools/relayer/issues/396