### PR TITLE
Ensure No-std Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     # Name should be the OS name only (e.g. Linux, macOS, Windows)
     # This is used to generate the badge
-    name: ${{ matrix.os }}-${{ matrix.features }}
+    name: webb crate (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v2
         with:
@@ -52,14 +52,13 @@ jobs:
           - evm,std
           - substrate,std
           - evm
-          - substrate
         test-features:
           - evm,std
           - substrate,std
     runs-on: ${{ matrix.os }}
     # Name should be the OS name only (e.g. Linux, macOS, Windows)
     # This is used to generate the badge
-    name: ${{ matrix.os }}-${{ matrix.features }}
+    name: proposals crate (${{ matrix.os }} with ${{ matrix.features }} / ${{ matrix.test-features }})
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  ci:
+  webb:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     # Name should be the OS name only (e.g. Linux, macOS, Windows)
     # This is used to generate the badge
-    name: ${{ matrix.os }}
+    name: ${{ matrix.os }}-${{ matrix.features }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -40,12 +40,44 @@ jobs:
       - name: Check Metadata generation
         run: cargo build --features generate-substrate,generate-contracts
       - name: Tests
-        run: cargo test --all
-      - name: EVM Proposals
-        run: cargo build -p webb-proposals --no-default-features --features evm,std
-      - name: Substrate Proposals
-        run: cargo build -p webb-proposals --no-default-features --features substrate,std
-      - name: Ink! Proposals
-        run: cargo build -p webb-proposals --no-default-features --features ink,std
+        run: cargo test -p webb
       - name: Rustdoc build
-        run: cargo doc --no-deps --all-features
+        run: cargo doc -p webb --no-deps --all-features
+
+  proposals:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        features:
+          - evm,std
+          - substrate,std
+          - evm
+          - substrate
+        test-features:
+          - evm,std
+          - substrate,std
+    runs-on: ${{ matrix.os }}
+    # Name should be the OS name only (e.g. Linux, macOS, Windows)
+    # This is used to generate the badge
+    name: ${{ matrix.os }}-${{ matrix.features }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Mold Linker
+        uses: rui314/setup-mold@v1
+      - name: Build
+        run: cargo build -p webb-proposals --no-default-features --features ${{ matrix.features }}
+      - name: Tests
+        run: cargo test -p webb-proposals --no-default-features --features ${{ matrix.test-features }}
+      - name: Rustdoc
+        run: cargo doc -p webb-proposals --no-deps --no-default-features --features ${{ matrix.features }}

--- a/proposal-derive/Cargo.toml
+++ b/proposal-derive/Cargo.toml
@@ -10,3 +10,7 @@ proc-macro = true
 ethers-core = { workspace = true }
 syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
+
+[features]
+default = ["std"]
+std = []

--- a/proposals/Cargo.toml
+++ b/proposals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webb-proposals"
-version = "0.7.0"
+version = "0.8.0"
 description = "Webb Protocol Proposals Specification & Implementation (part of webb-rs SDK)"
 categories = ["encoding", "no-std"]
 keywords = ["webb", "proposals", "protocol", "blockchain"]
@@ -23,6 +23,7 @@ serde = { workspace = true, optional = true, default-features = false, features 
 hex = { workspace = true, default-features = false, features = ["alloc"] }
 proposal-derive = { path = "../proposal-derive", default-features = false }
 thiserror = { workspace = true }
+sp-runtime-interface ={ default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.4"

--- a/proposals/Cargo.toml
+++ b/proposals/Cargo.toml
@@ -17,22 +17,23 @@ scale-codec = { package = 'parity-scale-codec', version = '3.0.0', default-featu
 scale-info = { version = "2.1.1", default-features = false, optional = true }
 frame-support = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0", optional = true }
 num-traits = { version = "0.2.15", default-features = false }
-typed-builder = { version = "0.15", default-features = false, optional = true }
+typed-builder = { version = "0.18", default-features = false, optional = true }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
-serde = { workspace = true, optional = true }
-hex = { workspace = true }
-proposal-derive = { path = "../proposal-derive" }
+serde = { workspace = true, optional = true, default-features = false, features = ["alloc", "derive"] }
+hex = { workspace = true, default-features = false, features = ["alloc"] }
+proposal-derive = { path = "../proposal-derive", default-features = false }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 hex-literal = "0.4"
 hex = { workspace = true }
-toml = { version = "0.7.2" }
+toml = { version = "0.8" }
+serde = { workspace = true, default-features = false, features = ["alloc"] }
 
 [features]
 default = ["std", "evm", "substrate", "scale", "ink"]
-std = ["scale-codec/std", "scale-info/std", "num-traits/std", "serde", "hex/std", "frame-support/std"]
+std = ["scale-codec/std", "scale-info/std", "num-traits/std", "serde/std", "hex/std", "frame-support/std", "proposal-derive/std"]
 scale = ["scale-codec", "scale-info/derive"]
-evm = []
+evm = ["serde"]
 substrate = ["scale", "typed-builder", "frame-support", "serde"]
 ink = ["scale", "typed-builder"]

--- a/proposals/src/header.rs
+++ b/proposals/src/header.rs
@@ -5,7 +5,6 @@ use crate::target_system::TargetSystem;
 use core::fmt::Debug;
 use core::fmt::Formatter;
 
-#[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 
 /// Proposal Target Function Signature (4 bytes).
@@ -19,8 +18,8 @@ use serde::{Deserialize, Serialize};
         scale_codec::MaxEncodedLen
     )
 )]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(transparent))]
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)]
 #[repr(transparent)]
 pub struct FunctionSignature(pub [u8; 4]);
 
@@ -35,7 +34,7 @@ pub struct FunctionSignature(pub [u8; 4]);
         scale_codec::MaxEncodedLen
     )
 )]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Serialize, Deserialize)]
 pub struct ResourceId(pub [u8; 32]);
 
 /// Proposal Target Chain and its type (6 bytes).
@@ -49,8 +48,8 @@ pub struct ResourceId(pub [u8; 32]);
         scale_codec::MaxEncodedLen
     )
 )]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(tag = "type", content = "id"))]
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type", content = "id")]
 #[non_exhaustive]
 pub enum TypedChainId {
     /// None chain type.
@@ -87,7 +86,7 @@ pub enum TypedChainId {
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[allow(clippy::module_name_repetitions)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Serialize, Deserialize)]
 pub struct ProposalHeader {
     /// Resource ID of the execution context
     pub resource_id: ResourceId,
@@ -532,7 +531,6 @@ impl Debug for FunctionSignature {
 /// # Errors
 /// This function will return an error if it fails to serialize the
 /// proposal header.
-#[cfg(feature = "std")]
 pub fn serialize<S>(
     header: &ProposalHeader,
     serializer: S,

--- a/proposals/src/lib.rs
+++ b/proposals/src/lib.rs
@@ -146,7 +146,5 @@ pub use proposal::*;
 pub use target_system::*;
 pub use traits::*;
 
-#[cfg(feature = "std")]
 pub use de::{from_slice, DeserializationError};
-#[cfg(feature = "std")]
 pub use ser::{to_vec, SerializationError};

--- a/proposals/src/nonce.rs
+++ b/proposals/src/nonce.rs
@@ -1,7 +1,6 @@
 use core::ops::{Add, Mul};
 use num_traits::{Bounded, CheckedMul, One, Saturating, Zero};
 
-#[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 
 /// Proposal Nonce (4 bytes).
@@ -15,8 +14,8 @@ use serde::{Deserialize, Serialize};
         scale_codec::MaxEncodedLen,
     )
 )]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(transparent))]
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)]
 #[repr(transparent)]
 pub struct Nonce(pub u32);
 
@@ -27,6 +26,7 @@ impl Add for Nonce {
         Nonce(self.0 + rhs.0)
     }
 }
+
 impl Mul for Nonce {
     type Output = Self;
 

--- a/proposals/src/proposal/evm/anchor_update.rs
+++ b/proposals/src/proposal/evm/anchor_update.rs
@@ -16,8 +16,17 @@ use proposal_derive::Proposal;
 /// │                    │                 │                     │
 /// └────────────────────┴─────────────────┴─────────────────────┘
 /// ```
-#[derive(Proposal, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Proposal,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[proposal(
     function_sig = "function updateEdge(uint256 root, uint32 latestLeafIndex, bytes32 srcResourceID)"
 )]

--- a/proposals/src/proposal/evm/fee_recipient_update.rs
+++ b/proposals/src/proposal/evm/fee_recipient_update.rs
@@ -16,8 +16,17 @@ use proposal_derive::Proposal;
 /// └────────────────────┴─────────────────────────┘
 /// ```
 
-#[derive(Proposal, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Proposal,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[proposal(
     function_sig = "function setFee(uint16 _feePercentage, uint32 _nonce)"
 )]

--- a/proposals/src/proposal/evm/max_deposit_limit.rs
+++ b/proposals/src/proposal/evm/max_deposit_limit.rs
@@ -16,8 +16,17 @@ use crate::ProposalHeader;
 /// │                    │                      │
 /// └────────────────────┴──────────────────────┘
 /// ```
-#[derive(Proposal, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Proposal,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[proposal(
     function_sig = "function configureMaximumDepositLimit(uint256 maximumDepositAmount, uint32 nonce)"
 )]

--- a/proposals/src/proposal/evm/min_withdrawal_limit.rs
+++ b/proposals/src/proposal/evm/min_withdrawal_limit.rs
@@ -16,8 +16,17 @@ use crate::ProposalHeader;
 /// │                    │                        │
 /// └────────────────────┴────────────────────────┘
 /// ```
-#[derive(Proposal, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Proposal,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[proposal(
     function_sig = "function configureMaximumDepositLimit(uint256 maximumDepositAmount, uint32 nonce)"
 )]

--- a/proposals/src/proposal/evm/rescue_tokens.rs
+++ b/proposals/src/proposal/evm/rescue_tokens.rs
@@ -16,8 +16,17 @@ use crate::ProposalHeader;
 /// │                    │                   │               │            │
 /// └────────────────────┴───────────────────┴───────────────┴────────────┘
 /// ```
-#[derive(Proposal, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Proposal,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[proposal(
     function_sig = "function rescueTokens(address _tokenAddress, address _to, uint256 _amountToRescue, uint32 _nonce)"
 )]

--- a/proposals/src/proposal/evm/resource_id_update.rs
+++ b/proposals/src/proposal/evm/resource_id_update.rs
@@ -15,8 +15,17 @@ use crate::{ProposalHeader, ResourceId};
 /// │                    │                   │                    │
 /// └────────────────────┴───────────────────┴────────────────────┘
 /// ```
-#[derive(Proposal, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Proposal,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[proposal(function_sig = "function adminSetResourceWithSignature(
 		bytes32 resourceID,
 		bytes4 functionSig,

--- a/proposals/src/proposal/evm/set_daily_withdrawal_limit.rs
+++ b/proposals/src/proposal/evm/set_daily_withdrawal_limit.rs
@@ -16,8 +16,17 @@ use crate::ProposalHeader;
 /// │                    │                           │
 /// └────────────────────┴───────────────────────────┘
 /// ```
-#[derive(Proposal, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Proposal,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[proposal(
     function_sig = "function setDailyWithdrawalLimit(uint256 _limit, uint32 _nonce)"
 )]

--- a/proposals/src/proposal/evm/set_native_allowed.rs
+++ b/proposals/src/proposal/evm/set_native_allowed.rs
@@ -16,8 +16,17 @@ use crate::ProposalHeader;
 /// │                    │                  │
 /// └────────────────────┴──────────────────┘
 /// ```
-#[derive(Proposal, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Proposal,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[proposal(
     function_sig = "function setNativeAllowed(bool _nativeAllowed, uint32 _nonce)"
 )]

--- a/proposals/src/proposal/evm/set_treasury_handler.rs
+++ b/proposals/src/proposal/evm/set_treasury_handler.rs
@@ -16,8 +16,17 @@ use crate::ProposalHeader;
 /// │                    │                            │
 /// └────────────────────┴────────────────────────────┘
 /// ```
-#[derive(Proposal, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Proposal,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[proposal(
     function_sig = "function setHandler(address _newHandler, uint32 _nonce)"
 )]

--- a/proposals/src/proposal/evm/set_verifier.rs
+++ b/proposals/src/proposal/evm/set_verifier.rs
@@ -15,8 +15,17 @@ use crate::ProposalHeader;
 /// │                    │                     │
 /// └────────────────────┴─────────────────────┘
 /// ```
-#[derive(Proposal, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Proposal,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[proposal(
     function_sig = "function setVerifier(address verifier, uint32 nonce)"
 )]

--- a/proposals/src/proposal/evm/token_add.rs
+++ b/proposals/src/proposal/evm/token_add.rs
@@ -16,8 +16,17 @@ use crate::ProposalHeader;
 /// │                    │                  │
 /// └────────────────────┴──────────────────┘
 /// ```
-#[derive(Proposal, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Proposal,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[proposal(function_sig = "function add(address _tokenAddress, uint32 _nonce)")]
 pub struct TokenAddProposal {
     header: ProposalHeader,

--- a/proposals/src/proposal/evm/token_remove.rs
+++ b/proposals/src/proposal/evm/token_remove.rs
@@ -17,8 +17,17 @@ use crate::ProposalHeader;
 /// │                    │                  │
 /// └────────────────────┴──────────────────┘
 /// ```
-#[derive(Proposal, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Proposal,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[proposal(
     function_sig = "function remove(address _tokenAddress, uint32 _nonce)"
 )]

--- a/proposals/src/proposal/evm/wrapping_fee_update.rs
+++ b/proposals/src/proposal/evm/wrapping_fee_update.rs
@@ -20,8 +20,17 @@ use crate::ProposalHeader;
 /// The wrapping fee percentage is a number between 0 and 10000.
 ///
 /// For example, a fee of `42.20%` is encoded as `4220`.
-#[derive(Proposal, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Proposal,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[proposal(
     function_sig = "function setFee(uint16 _feePercentage, uint32 _nonce)"
 )]

--- a/proposals/src/ser.rs
+++ b/proposals/src/ser.rs
@@ -1,17 +1,33 @@
 //! Serializer for Webb Proposals Foramt.
 use serde::ser::{self, Serialize};
 
+#[cfg(not(feature = "std"))]
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
 /// Error that can occur during serialization.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SerializationError {
     /// Custom error message from [serde].
-    #[error("{0}")]
     Custom(String),
     /// Unsupported type encountered.
-    #[error("Unsupported type")]
     Unspported,
 }
+
+impl core::fmt::Display for SerializationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self {
+            Self::Custom(msg) => write!(f, "{msg}"),
+            Self::Unspported => write!(f, "Unsupported type"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SerializationError {}
 
 impl ser::Error for SerializationError {
     fn custom<T: core::fmt::Display>(msg: T) -> Self {

--- a/proposals/src/target_system.rs
+++ b/proposals/src/target_system.rs
@@ -25,6 +25,7 @@
 
 #[cfg(all(not(feature = "std"), feature = "substrate"))]
 use alloc::vec::Vec;
+
 /// `TargetSystem` (26 Bytes)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(
@@ -168,6 +169,7 @@ impl From<TargetSystem> for [u8; TargetSystem::LENGTH] {
         target_system.into_bytes()
     }
 }
+
 #[cfg(feature = "substrate")]
 impl Default for TargetSystem {
     fn default() -> Self {


### PR DESCRIPTION
- Make everything no-std first, then adding std is an option
- EVM proposals could be used with no std support (serde still works)
- for some reason, when running tests, it always expects std to be enabled.
- Substrate's `frame_support` expects when we are run without std, we are running inside a 32-bit system (a la WASM) and refuse to compile without std in normal systems (64-bit).